### PR TITLE
Fix error when throwing a non-XpBottles bottle with NBT data

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'me.codedred'
-version = '1.3.3'
+version = '1.3.4'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8

--- a/v1_10_R1/src/main/java/me/codedred/xpbottles/versions/Version_v1_10_R1.java
+++ b/v1_10_R1/src/main/java/me/codedred/xpbottles/versions/Version_v1_10_R1.java
@@ -34,7 +34,7 @@ public class Version_v1_10_R1 implements VersionData {
 
 	public boolean hasValue(ItemStack item) {
 		net.minecraft.server.v1_10_R1.ItemStack nmsItem = CraftItemStack.asNMSCopy(item);
-		return nmsItem.hasTag();
+		return nmsItem.hasTag() && !nmsItem.getTag().getList("AttributeModifiers", 10).isEmpty();
 	}
 
 	public int getExpAmount(ItemStack item) {

--- a/v1_11_R1/src/main/java/me/codedred/xpbottles/versions/Version_v1_11_R1.java
+++ b/v1_11_R1/src/main/java/me/codedred/xpbottles/versions/Version_v1_11_R1.java
@@ -34,7 +34,7 @@ public class Version_v1_11_R1 implements VersionData {
 
 	public boolean hasValue(ItemStack item) {
 		net.minecraft.server.v1_11_R1.ItemStack nmsItem = CraftItemStack.asNMSCopy(item);
-		return nmsItem.hasTag();
+		return nmsItem.hasTag() && !nmsItem.getTag().getList("AttributeModifiers", 10).isEmpty();
 	}
 
 	public int getExpAmount(ItemStack item) {

--- a/v1_12_R1/src/main/java/me/codedred/xpbottles/versions/Version_v1_12_R1.java
+++ b/v1_12_R1/src/main/java/me/codedred/xpbottles/versions/Version_v1_12_R1.java
@@ -34,7 +34,7 @@ public class Version_v1_12_R1 implements VersionData {
 
 	public boolean hasValue(ItemStack item) {
 		net.minecraft.server.v1_12_R1.ItemStack nmsItem = CraftItemStack.asNMSCopy(item);
-		return nmsItem.hasTag();
+		return nmsItem.hasTag() && !nmsItem.getTag().getList("AttributeModifiers", 10).isEmpty();
 	}
 
 	public int getExpAmount(ItemStack item) {

--- a/v1_13_R2/src/main/java/me/codedred/xpbottles/versions/Version_v1_13_R2.java
+++ b/v1_13_R2/src/main/java/me/codedred/xpbottles/versions/Version_v1_13_R2.java
@@ -34,7 +34,7 @@ public class Version_v1_13_R2 implements VersionData {
 
 	public boolean hasValue(ItemStack item) {
 		net.minecraft.server.v1_13_R2.ItemStack nmsItem = CraftItemStack.asNMSCopy(item);
-		return nmsItem.hasTag();
+		return nmsItem.hasTag() && !nmsItem.getTag().getList("AttributeModifiers", 10).isEmpty();
 	}
 
 	public int getExpAmount(ItemStack item) {

--- a/v1_14_R1/src/main/java/me/codedred/xpbottles/versions/Version_v1_14_R1.java
+++ b/v1_14_R1/src/main/java/me/codedred/xpbottles/versions/Version_v1_14_R1.java
@@ -34,7 +34,7 @@ public class Version_v1_14_R1 implements VersionData {
 
 	public boolean hasValue(ItemStack item) {
 		net.minecraft.server.v1_14_R1.ItemStack nmsItem = CraftItemStack.asNMSCopy(item);
-		return nmsItem.hasTag();
+		return nmsItem.hasTag() && !nmsItem.getTag().getList("AttributeModifiers", 10).isEmpty();
 	}
 
 	public int getExpAmount(ItemStack item) {

--- a/v1_15_R1/src/main/java/me/codedred/xpbottles/versions/Version_v1_15_R1.java
+++ b/v1_15_R1/src/main/java/me/codedred/xpbottles/versions/Version_v1_15_R1.java
@@ -34,7 +34,7 @@ public class Version_v1_15_R1 implements VersionData {
 
 	public boolean hasValue(ItemStack item) {
 		net.minecraft.server.v1_15_R1.ItemStack nmsItem = CraftItemStack.asNMSCopy(item);
-		return nmsItem.hasTag();
+		return nmsItem.hasTag() && !nmsItem.getTag().getList("AttributeModifiers", 10).isEmpty();
 	}
 
 	public int getExpAmount(ItemStack item) {

--- a/v1_16_R1/src/main/java/me/codedred/xpbottles/versions/Version_v1_16_R1.java
+++ b/v1_16_R1/src/main/java/me/codedred/xpbottles/versions/Version_v1_16_R1.java
@@ -39,7 +39,7 @@ public class Version_v1_16_R1 implements VersionData {
 
 	public boolean hasValue(ItemStack item) {
 		net.minecraft.server.v1_16_R1.ItemStack nmsItem = CraftItemStack.asNMSCopy(item);
-		return nmsItem.hasTag();
+		return nmsItem.hasTag() && !nmsItem.getTag().getList("AttributeModifiers", 10).isEmpty();
 	}
 
 	// TODO update this?

--- a/v1_16_R2/src/main/java/me/codedred/xpbottles/versions/Version_v1_16_R2.java
+++ b/v1_16_R2/src/main/java/me/codedred/xpbottles/versions/Version_v1_16_R2.java
@@ -39,7 +39,7 @@ public class Version_v1_16_R2 implements VersionData {
 
 	public boolean hasValue(ItemStack item) {
 		net.minecraft.server.v1_16_R2.ItemStack nmsItem = CraftItemStack.asNMSCopy(item);
-		return nmsItem.hasTag();
+		return nmsItem.hasTag() && !nmsItem.getTag().getList("AttributeModifiers", 10).isEmpty();
 	}
 
 	// TODO update this?

--- a/v1_16_R3/src/main/java/me/codedred/xpbottles/versions/Version_v1_16_R3.java
+++ b/v1_16_R3/src/main/java/me/codedred/xpbottles/versions/Version_v1_16_R3.java
@@ -39,7 +39,7 @@ public class Version_v1_16_R3 implements VersionData {
 
 	public boolean hasValue(ItemStack item) {
 		net.minecraft.server.v1_16_R3.ItemStack nmsItem = CraftItemStack.asNMSCopy(item);
-		return nmsItem.hasTag();
+		return nmsItem.hasTag() && !nmsItem.getTag().getList("AttributeModifiers", 10).isEmpty();
 	}
 
 	// TODO update this?

--- a/v1_17_R1/src/main/java/me/codedred/xpbottles/versions/Version_v1_17_R1.java
+++ b/v1_17_R1/src/main/java/me/codedred/xpbottles/versions/Version_v1_17_R1.java
@@ -39,7 +39,7 @@ public class Version_v1_17_R1 implements VersionData {
 
 	public boolean hasValue(ItemStack item) {
 		net.minecraft.world.item.ItemStack nmsItem = CraftItemStack.asNMSCopy(item);
-		return nmsItem.hasTag();
+		return nmsItem.hasTag() && !nmsItem.getTag().getList("AttributeModifiers", 10).isEmpty();
 	}
 
 	// TODO update this?

--- a/v1_18_R2/src/main/java/me/codedred/xpbottles/versions/Version_v1_18_R2.java
+++ b/v1_18_R2/src/main/java/me/codedred/xpbottles/versions/Version_v1_18_R2.java
@@ -39,7 +39,7 @@ public class Version_v1_18_R2 implements VersionData {
 
 	public boolean hasValue(ItemStack item) {
 		net.minecraft.world.item.ItemStack nmsItem = CraftItemStack.asNMSCopy(item);
-		return nmsItem.hasTag();
+		return nmsItem.hasTag() && !nmsItem.getTag().getList("AttributeModifiers", 10).isEmpty();
 	}
 
 	// TODO update this?

--- a/v1_8_R3/src/main/java/me/codedred/xpbottles/versions/Version_v1_8_R3.java
+++ b/v1_8_R3/src/main/java/me/codedred/xpbottles/versions/Version_v1_8_R3.java
@@ -34,7 +34,7 @@ public class Version_v1_8_R3 implements VersionData {
 
 	public boolean hasValue(ItemStack item) {
 		net.minecraft.server.v1_8_R3.ItemStack nmsItem = CraftItemStack.asNMSCopy(item);
-		return nmsItem.hasTag();
+		return nmsItem.hasTag() && !nmsItem.getTag().getList("AttributeModifiers", 10).isEmpty();
 	}
 
 	public int getExpAmount(ItemStack item) {

--- a/v1_9_R2/src/main/java/me/codedred/xpbottles/versions/Version_v1_9_R2.java
+++ b/v1_9_R2/src/main/java/me/codedred/xpbottles/versions/Version_v1_9_R2.java
@@ -34,7 +34,7 @@ public class Version_v1_9_R2 implements VersionData {
 
 	public boolean hasValue(ItemStack item) {
 		net.minecraft.server.v1_9_R2.ItemStack nmsItem = CraftItemStack.asNMSCopy(item);
-		return nmsItem.hasTag();
+		return nmsItem.hasTag() && !nmsItem.getTag().getList("AttributeModifiers", 10).isEmpty();
 	}
 
 	public int getExpAmount(ItemStack item) {


### PR DESCRIPTION
Fixes an IndexOutOfBoundsException when throwing an XP bottle that has NBT data, but isn't from XpBottles.